### PR TITLE
Process without a identifier (eg. a deposit) wasn't handled correctly

### DIFF
--- a/src/Domain/Process.php
+++ b/src/Domain/Process.php
@@ -29,7 +29,7 @@ final class Process implements DomainObjectInterface
 
     public string $type;
 
-    public string $identifier;
+    public ?string $identifier;
 
     public string $action;
 
@@ -67,7 +67,7 @@ final class Process implements DomainObjectInterface
         string $status,
         DateTimeInterface $createdDate,
         string $type,
-        string $identifier,
+        ?string $identifier,
         string $action,
         array $command,
         ?DateTimeInterface $updatedDate,
@@ -147,7 +147,7 @@ final class Process implements DomainObjectInterface
             $json['status'],
             new DateTimeImmutable($json['createdDate']),
             $json['type'],
-            $json['identifier'],
+            $json['identifier'] ?? null,
             $json['action'],
             $json['command'],
             isset($json['updatedDate']) ? new DateTimeImmutable($json['updatedDate']) : null,

--- a/tests/Clients/Processes/ProcessesApiListTest.php
+++ b/tests/Clients/Processes/ProcessesApiListTest.php
@@ -36,6 +36,31 @@ class ProcessesApiListTest extends TestCase
         $sdk->processes->list();
     }
 
+    public function test_process_without_identifier()
+    {
+        /** @var string $responseBody */
+        $responseBody = json_encode(
+            [
+                'entities' => [
+                    include __DIR__ . '/../../Domain/data/processes/process_without_identifier.php',
+                ],
+                'pagination' => [
+                    'total' => 1,
+                    'offset' => 0,
+                    'limit' => 10,
+                ],
+            ]
+        );
+        Assert::string($responseBody);
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            $responseBody,
+            MockedClientFactory::assertRoute('GET', 'v2/processes', $this)
+        );
+
+        $sdk->processes->list();
+    }
+
     public function test_list_with_queries(): void
     {
         /** @var string $responseBody */

--- a/tests/Domain/data/processes/process_without_identifier.php
+++ b/tests/Domain/data/processes/process_without_identifier.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+return [
+    'id' => 46069000,
+    'user' => 'johndoe/died',
+    'customer' => 'johndoe',
+    'status' => 'COMPLETED',
+    'createdDate' => '2021-08-11T06:17:15Z',
+    'updatedDate' => '2021-08-25T06:17:15Z',
+    'startedDate' => '2021-08-11T06:17:15Z',
+    'action' => 'deposit',
+    'type' => 'billing',
+    'command' => [
+        'customer' => 'johndoe',
+        'amount' => 1337,
+        'currency' => 'EUR',
+        'method' => 'PAYPAL',
+        'reference' => 'Test',
+        'userIp' => '127.0.0.1',
+        'paymentCurrency' => 'EUR',
+    ],
+];


### PR DESCRIPTION
Fix for sandwave-io/realtimeregister-php/issues/88,  which was also present in our code