### PR TITLE
introduced NotificationType and EventType enums and updated test fixt…

### DIFF
--- a/src/Domain/Enum/EventTypeEnum.php
+++ b/src/Domain/Enum/EventTypeEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace RealtimeRegister\Domain\Enum;
+
+enum EventTypeEnum: string
+{
+    case RequestCertificateEvent = 'RequestCertificateEvent';
+    case CreateDomainEvent = 'CreateDomainEvent';
+    case DeleteDomainEvent = 'DeleteDomainEvent';
+    case RenewDomainEvent = 'RenewDomainEvent';
+    case UpdateDomainEvent = 'UpdateDomainEvent';
+    case TransferDomainEvent = 'TransferDomainEvent';
+    case SSLCertificateExpiryReportEvent = 'SSLCertificateExpiryReportEvent';
+    case TestEvent = 'TestEvent';
+}

--- a/src/Domain/Enum/NotificationTypeEnum.php
+++ b/src/Domain/Enum/NotificationTypeEnum.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace RealtimeRegister\Domain\Enum;
+
+enum NotificationTypeEnum: string
+{
+    case SSLCertificateNotification = 'SSLCertificateNotification';
+    case CreateDomainNotification = 'CreateDomainNotification';
+    case DeleteDomainNotification = 'DeleteDomainNotification';
+    case RenewDomainNotification = 'RenewDomainNotification';
+    case UpdateDomainNotification = 'UpdateDomainNotification';
+    case TransferDomainNotification = 'TransferDomainNotification';
+    case DomainNotification = 'DomainNotification';
+    case SSLCertificateExpiryReportNotification = 'SSLCertificateExpiryReportNotification';
+    case TestNotification = 'TestNotification';
+}

--- a/src/Domain/Notification.php
+++ b/src/Domain/Notification.php
@@ -3,6 +3,8 @@
 namespace RealtimeRegister\Domain;
 
 use DateTime;
+use RealtimeRegister\Domain\Enum\EventTypeEnum;
+use RealtimeRegister\Domain\Enum\NotificationTypeEnum;
 
 final class Notification implements DomainObjectInterface
 {
@@ -24,9 +26,9 @@ final class Notification implements DomainObjectInterface
 
     public ?int $process;
 
-    public string $eventType;
+    public EventTypeEnum $eventType;
 
-    public string $notificationType;
+    public NotificationTypeEnum $notificationType;
 
     /** @var array<string>|null */
     public ?array $payload;
@@ -49,8 +51,8 @@ final class Notification implements DomainObjectInterface
         ?string $reason,
         ?string $customer,
         ?int $process,
-        string $eventType,
-        string $notificationType,
+        EventTypeEnum $eventType,
+        NotificationTypeEnum $notificationType,
         bool $isAsync,
         ?array $payload = null,
         ?string $processIdentifier = null,
@@ -77,6 +79,9 @@ final class Notification implements DomainObjectInterface
 
     public static function fromArray(array $json): Notification
     {
+        $eventType = EventTypeEnum::from($json['eventType']);
+        $notificationType = NotificationTypeEnum::from($json['notificationType']);
+
         return new Notification(
             $json['id'],
             new DateTime($json['fireDate']),
@@ -87,8 +92,8 @@ final class Notification implements DomainObjectInterface
             $json['reason'] ?? null,
             $json['customer'] ?? null,
             $json['process'] ?? null,
-            $json['eventType'],
-            $json['notificationType'],
+            $eventType,
+            $notificationType,
             $json['isAsync'],
             $json['payload'] ?? null,
             $json['processIdentifier'] ?? null,
@@ -109,8 +114,8 @@ final class Notification implements DomainObjectInterface
             'reason' => $this->reason,
             'customer' => $this->customer,
             'process' => $this->process,
-            'eventType' => $this->eventType,
-            'notificationType' => $this->notificationType,
+            'eventType' => $this->eventType->value,
+            'notificationType' => $this->notificationType->value,
             'payload' => $this->payload,
             'isAsync' => $this->isAsync,
             'processIdentifier' => $this->processIdentifier,

--- a/tests/Domain/data/notifications/notification_invalid_id.php
+++ b/tests/Domain/data/notifications/notification_invalid_id.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types = 1);
 
+use RealtimeRegister\Domain\Enum\EventTypeEnum;
+use RealtimeRegister\Domain\Enum\NotificationTypeEnum;
+
 return [
     'id' => 'one',
     'fireDate' => '2020-08-30T01:02:03Z',
@@ -10,7 +13,7 @@ return [
     'customer' => 'johndoe',
     'process' => 1,
     'isAsync' => true,
-    'eventType' => 'FAKE_EVENT_TYPE',
-    'notificationType' => 'FAKE_NOTIFICATION_TYPE',
+    'eventType' => EventTypeEnum::TestEvent->value,
+    'notificationType' => NotificationTypeEnum::TestNotification->value,
     'payload' => ['customer' => 'johndoe'],
 ];

--- a/tests/Domain/data/notifications/notification_valid.php
+++ b/tests/Domain/data/notifications/notification_valid.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types = 1);
 
+use RealtimeRegister\Domain\Enum\EventTypeEnum;
+use RealtimeRegister\Domain\Enum\NotificationTypeEnum;
+
 return [
     'id' => 1,
     'fireDate' => '2020-08-30T01:02:03Z',
@@ -10,8 +13,8 @@ return [
     'reason' => 'FAKE_REASON',
     'customer' => 'johndoe',
     'process' => 1,
-    'eventType' => 'FAKE_EVENT_TYPE',
-    'notificationType' => 'FAKE_NOTIFICATION_TYPE',
+    'eventType' => EventTypeEnum::TestEvent->value,
+    'notificationType' => NotificationTypeEnum::TestNotification->value,
     'payload' => ['customer' => 'johndoe'],
     'isAsync' => true,
 ];

--- a/tests/Domain/data/notifications/notification_valid_only_required.php
+++ b/tests/Domain/data/notifications/notification_valid_only_required.php
@@ -1,10 +1,13 @@
 <?php declare(strict_types = 1);
 
+use RealtimeRegister\Domain\Enum\EventTypeEnum;
+use RealtimeRegister\Domain\Enum\NotificationTypeEnum;
+
 return [
     'id' => 1,
     'fireDate' => '2020-08-30T01:02:03Z',
     'message' => 'FAKEMESSAGE',
-    'eventType' => 'FAKE_EVENT_TYPE',
-    'notificationType' => 'FAKE_NOTIFICATION_TYPE',
+    'eventType' => EventTypeEnum::TestEvent->value,
+    'notificationType' => NotificationTypeEnum::TestNotification->value,
     'isAsync' => true,
 ];


### PR DESCRIPTION
This PR replaces stringly-typed notification fields with backed enums for type safety

- Notification::$eventType → EventTypeEnum
- Notification::$notificationType → NotificationTypeEnum

Serialization stays wire compatible: fromArray() reads strings and maps to enums, toArray() outputs strings (->value)