### PR TITLE
Added missing toArray call to convert collection to array

### DIFF
--- a/src/Api/DomainsApi.php
+++ b/src/Api/DomainsApi.php
@@ -89,7 +89,7 @@ final class DomainsApi extends AbstractApi
         ];
 
         if ($records !== null) {
-            $data['records'] = $records;
+            $data['records'] = $records->toArray();
         }
 
         $this->client->post(sprintf('v2/domains/%s/zone/update', urlencode($domainName)), $data);


### PR DESCRIPTION
Based on the code in the `DnsZonesApi->create` and `DnsZonesApi->update` calls, a toArray function should be added in the `DomainsApi->update` method as well.

Fixes the error described in #40