### PR TITLE
Add process to certificate

### DIFF
--- a/src/Domain/Certificate.php
+++ b/src/Domain/Certificate.php
@@ -12,6 +12,8 @@ final class Certificate implements DomainObjectInterface
 {
     public int $id;
 
+    public int $process;
+
     public string $product;
 
     public string $validationType;
@@ -62,6 +64,7 @@ final class Certificate implements DomainObjectInterface
 
     private function __construct(
         int $id,
+        int $process,
         string $product,
         string $validationType,
         string $certificateType,
@@ -87,6 +90,7 @@ final class Certificate implements DomainObjectInterface
         ?string $fingerprint = null
     ) {
         $this->id = $id;
+        $this->process = $process;
         $this->product = $product;
         $this->validationType = $validationType;
         $this->certificateType = $certificateType;
@@ -121,6 +125,7 @@ final class Certificate implements DomainObjectInterface
 
         return new Certificate(
             $json['id'],
+            $json['process'],
             $json['product'],
             $json['validationType'],
             $json['certificateType'],
@@ -151,6 +156,7 @@ final class Certificate implements DomainObjectInterface
     {
         return array_filter([
             'id' => $this->id,
+            'process' => $this->process,
             'product' => $this->product,
             'validationType' => $this->validationType,
             'certificateType' => $this->certificateType,

--- a/tests/Clients/Certificates/CertificatesApiGetCertificateTest.php
+++ b/tests/Clients/Certificates/CertificatesApiGetCertificateTest.php
@@ -21,6 +21,7 @@ class CertificatesApiGetCertificateTest extends TestCase
             200,
             json_encode([
                 'id' => 1,
+                'process' => 1,
                 'product' => 'ssl',
                 'validationType' => ValidationTypeEnum::VALIDATION_TYPE_DOMAIN_VALIDATION,
                 'certificateType' => CertificateTypeEnum::LOCALE_SINGLE_DOMAIN,

--- a/tests/Domain/data/certificates/certificate_valid.php
+++ b/tests/Domain/data/certificates/certificate_valid.php
@@ -7,6 +7,7 @@ use RealtimeRegister\Domain\Enum\ValidationTypeEnum;
 
 return [
     'id' => 1234567,
+    'process' => 1,
     'product' => 'ssl_sectigo',
     'validationType' => ValidationTypeEnum::VALIDATION_TYPE_DOMAIN_VALIDATION,
     'certificateType' => CertificateTypeEnum::LOCALE_SINGLE_DOMAIN,


### PR DESCRIPTION
 In [https://dm.realtimeregister.com/docs/api/ssl/get](https://dm.realtimeregister.com/docs/api/ssl/get) there is a process but not in the class.
 
 Now it is hard to know the process id of the certificate if you did not save it before.