### PR TITLE
Fix contact update

### DIFF
--- a/src/Api/ContactsApi.php
+++ b/src/Api/ContactsApi.php
@@ -140,13 +140,13 @@ final class ContactsApi extends AbstractApi
         if ($brand) {
             $payload['brand'] = $brand;
         }
-        if ($organization) {
+        if (is_string($organization)) {
             $payload['organization'] = $organization;
         }
-        if ($state) {
+        if (is_string($state)) {
             $payload['state'] = $state;
         }
-        if ($fax) {
+        if (is_string($fax)) {
             $payload['fax'] = $fax;
         }
         if ($disclosedFields) {

--- a/tests/Clients/Contacts/ContactsApiUpdateTest.php
+++ b/tests/Clients/Contacts/ContactsApiUpdateTest.php
@@ -31,4 +31,29 @@ class ContactsApiUpdateTest extends TestCase
             '+31655555555'
         );
     }
+
+    public function test_update_with_empty_fields(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            '',
+            MockedClientFactory::assertRoute('POST', 'v2/customers/johndoe/contacts/test/update', $this, expectedFields: [
+                'customer' => 'johndoe',
+                'handle' => 'test',
+                'name' => 'John Doe',
+                'organization' => '',
+                'state' => '',
+                'fax' => '',
+            ])
+        );
+
+        $sdk->contacts->update(
+            customer: 'johndoe',
+            handle: 'test',
+            name: 'John Doe',
+            organization: '',
+            state: '',
+            fax: '',
+        );
+    }
 }

--- a/tests/Clients/Domains/DomainsApiUpdateTest.php
+++ b/tests/Clients/Domains/DomainsApiUpdateTest.php
@@ -69,6 +69,26 @@ class DomainsApiUpdateTest extends TestCase
         );
     }
 
+    public function test_update_empty_fields(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            '',
+            MockedClientFactory::assertRoute('POST', 'v2/domains/example.com/update', $this, expectedFields: [
+                'authcode' => '',
+                'ns' => [],
+                'keyData' => [],
+            ])
+        );
+
+        $sdk->domains->update(
+            domainName: 'example.com',
+            authcode: '',
+            ns: [],
+            keyData: KeyDataCollection::fromArray([])
+        );
+    }
+
     public function test_free_update(): void
     {
         $sdk = MockedClientFactory::makeSdk(

--- a/tests/Helpers/MockedClientFactory.php
+++ b/tests/Helpers/MockedClientFactory.php
@@ -16,9 +16,9 @@ class MockedClientFactory
 {
     const API_KEY = 'bigsecretdonttellanyone';
 
-    public static function assertRoute(string $method, string $route, TestCase $testCase, ?array $expectedParameters = null): callable
+    public static function assertRoute(string $method, string $route, TestCase $testCase, ?array $expectedParameters = null, ?array $expectedFields = null): callable
     {
-        return function (RequestInterface $request) use ($method, $route, $testCase, $expectedParameters) {
+        return function (RequestInterface $request) use ($method, $route, $testCase, $expectedParameters, $expectedFields) {
             $testCase->assertSame(strtoupper($method), strtoupper($request->getMethod()));
             $testCase->assertSame($route, $request->getUri()->getPath());
             $testCase->assertSame('ApiKey ' . static::API_KEY, $request->getHeader('Authorization')[0]);
@@ -26,6 +26,10 @@ class MockedClientFactory
             if (null !== $expectedParameters) {
                 parse_str($request->getUri()->getQuery(), $parameters);
                 $testCase->assertSame($expectedParameters, $parameters);
+            }
+
+            if (null !== $expectedFields) {
+                $testCase->assertSame($expectedFields, json_decode($request->getBody()->getContents(), true));
             }
         };
     }


### PR DESCRIPTION
This pull request improves the handling and testing of empty string fields in update operations for both contacts and domains APIs. The main focus is to ensure that empty values are correctly passed and validated in the payloads, and that the test infrastructure supports this verification.

**Testing improvements for empty fields:**

* Added a new test `test_update_with_empty_fields` in `ContactsApiUpdateTest.php` to verify that empty strings for `organization`, `state`, and `fax` are properly sent in the payload when updating a contact.
* Added a new test `test_update_empty_fields` in `DomainsApiUpdateTest.php` to verify that empty values for `authcode`, `ns`, and `keyData` are properly sent in the payload when updating a domain.

**API and test infrastructure changes:**

* Updated the `update` method in `ContactsApi.php` to check for string type before including `organization`, `state`, and `fax` in the payload, ensuring empty strings are handled correctly.
* Enhanced the `MockedClientFactory::assertRoute` helper to accept and validate expected fields in the request body, supporting more robust payload verification in tests. [[1]](diffhunk://#diff-1e5d021bdaa0617d41595e14c0cb503f69a2e2b211e0761379542c94f2280f98L19-R21) [[2]](diffhunk://#diff-1e5d021bdaa0617d41595e14c0cb503f69a2e2b211e0761379542c94f2280f98R30-R33)