### PR TITLE
Remove deprecated enum validation

### DIFF
--- a/src/Domain/Enum/ValidationCategoryEnum.php
+++ b/src/Domain/Enum/ValidationCategoryEnum.php
@@ -12,7 +12,6 @@ class ValidationCategoryEnum extends AbstractEnum
     const VALIDATION_CATEGORY_IIS_SE = 'IisSe';
     const VALIDATION_CATEGORY_NOMINET = 'Nominet';
     const VALIDATION_CATEGORY_SKNIC = 'SKNic';
-    const VALIDATION_CATEGORY_ESNIC = 'Esnic';
 
     protected static array $values = [
         ValidationCategoryEnum::VALIDATION_CATEGORY_GENERAL,
@@ -20,7 +19,6 @@ class ValidationCategoryEnum extends AbstractEnum
         ValidationCategoryEnum::VALIDATION_CATEGORY_IIS_SE,
         ValidationCategoryEnum::VALIDATION_CATEGORY_NOMINET,
         ValidationCategoryEnum::VALIDATION_CATEGORY_SKNIC,
-        ValidationCategoryEnum::VALIDATION_CATEGORY_ESNIC,
     ];
 
     /** @param string $value */

--- a/src/Domain/Enum/ValidationCategoryEnum.php
+++ b/src/Domain/Enum/ValidationCategoryEnum.php
@@ -12,6 +12,7 @@ class ValidationCategoryEnum extends AbstractEnum
     const VALIDATION_CATEGORY_IIS_SE = 'IisSe';
     const VALIDATION_CATEGORY_NOMINET = 'Nominet';
     const VALIDATION_CATEGORY_SKNIC = 'SKNic';
+    const VALIDATION_CATEGORY_ESNIC = 'Esnic';
 
     protected static array $values = [
         ValidationCategoryEnum::VALIDATION_CATEGORY_GENERAL,
@@ -19,6 +20,7 @@ class ValidationCategoryEnum extends AbstractEnum
         ValidationCategoryEnum::VALIDATION_CATEGORY_IIS_SE,
         ValidationCategoryEnum::VALIDATION_CATEGORY_NOMINET,
         ValidationCategoryEnum::VALIDATION_CATEGORY_SKNIC,
+        ValidationCategoryEnum::VALIDATION_CATEGORY_ESNIC,
     ];
 
     /** @param string $value */

--- a/src/Domain/Validation.php
+++ b/src/Domain/Validation.php
@@ -25,8 +25,6 @@ class Validation implements DomainObjectInterface
 
     public static function fromArray(array $json): Validation
     {
-        ValidationCategoryEnum::validate($json['category']);
-
         return new Validation(
             new \DateTime($json['validatedOn']),
             $json['version'],

--- a/src/Domain/Validation.php
+++ b/src/Domain/Validation.php
@@ -3,7 +3,6 @@
 namespace RealtimeRegister\Domain;
 
 use DateTimeInterface;
-use RealtimeRegister\Domain\Enum\ValidationCategoryEnum;
 
 class Validation implements DomainObjectInterface
 {


### PR DESCRIPTION
Currently the ContactsApi::get function gives us the following exception:

`Unexpected ENUM value in in class RealtimeRegister\\Domain\\Enum\\ValidationCategoryEnum: Esnic. Possible values: (General, IisNu, IisSe, Nominet, SKNic)`

This seems to be related to the depreciation of this enum in the previous tag. The enum is still used in `src/Domain/Validation::fromArray`.