### PR TITLE
Handle missing expiryDate in DomainRegistration::fromArray()

### DIFF
--- a/src/Domain/DomainRegistration.php
+++ b/src/Domain/DomainRegistration.php
@@ -32,9 +32,11 @@ class DomainRegistration implements DomainObjectInterface
             }
         }
 
+        $expiryDate = $json['expiryDate'] ?? null;
+
         return new DomainRegistration(
             $json['domainName'],
-            $json['expiryDate'] ? new DateTime($json['expiryDate']) : null,
+            $expiryDate !== null ? new DateTime($expiryDate) : null,
             $json['status'] ?? null,
         );
     }


### PR DESCRIPTION
Some domain registration responses omit expiryDate. Accessing `$json['expiryDate']` directly could therefore trigger an Undefined array key "expiryDate" error.

This change safely reads the value with `??` and only creates a `DateTime` instance when a value is present, matching the nullable `?DateTime` property.