### PR TITLE
phpunit minimum version upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.14.4",
         "phpstan/phpstan": "^1.10.6",
-        "phpunit/phpunit": "^10.0.15",
+        "phpunit/phpunit": "^10.5.63",
         "sandwave-io/php-cs-fixer-config": "^1.0.0"
     },
     "autoload": {


### PR DESCRIPTION
Because of https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-qrr6-mg7r-m243 we've upgraded the minimum version of phpunit we require