### PR TITLE
Make new TLD fields nullable as the API doesn't always return them

### DIFF
--- a/src/Domain/TLDMetaData.php
+++ b/src/Domain/TLDMetaData.php
@@ -76,7 +76,7 @@ final class TLDMetaData implements DomainObjectInterface
 
     public string $gdprCategory;
 
-    public string $premiumSupport;
+    public ?string $premiumSupport;
 
     public DomainSyntax $domainSyntax;
 
@@ -94,9 +94,9 @@ final class TLDMetaData implements DomainObjectInterface
 
     public ?LaunchPhaseCollection $launchPhases;
 
-    public bool $wdrpNotifications;
+    public ?bool $wdrpNotifications;
 
-    public bool $errpNotifications;
+    public ?bool $errpNotifications;
 
     public ?int $transferLockDays;
 
@@ -139,9 +139,9 @@ final class TLDMetaData implements DomainObjectInterface
         ?string $jurisdiction,
         ?string $termsOfService,
         ?string $privacyPolicy,
-        string $premiumSupport,
-        bool $wdrpNotifications,
-        bool $errpNotifications,
+        ?string $premiumSupport,
+        ?bool $wdrpNotifications,
+        ?bool $errpNotifications,
         ?int $transferLockDays
     ) {
         $this->createDomainPeriods = $createDomainPeriods;
@@ -204,7 +204,10 @@ final class TLDMetaData implements DomainObjectInterface
         }
         WhoisExposureEnum::validate($json['whoisExposure']);
         GDPRCategoryEnum::validate($json['gdprCategory']);
-        PremiumSupportEnum::validate($json['premiumSupport']);
+
+        if (isset($json['premiumSupport'])) {
+            PremiumSupportEnum::validate($json['premiumSupport']);
+        }
 
         return new TLDMetaData(
             $json['createDomainPeriods'],
@@ -245,9 +248,9 @@ final class TLDMetaData implements DomainObjectInterface
             $json['jurisdiction'] ?? null,
             $json['termsOfService'] ?? null,
             $json['privacyPolicy'] ?? null,
-            $json['premiumSupport'],
-            $json['wdrpNotifications'],
-            $json['errpNotifications'],
+            $json['premiumSupport'] ?? null,
+            $json['wdrpNotifications'] ?? null,
+            $json['errpNotifications'] ?? null,
             $json['transferLockDays'] ?? null
         );
     }

--- a/tests/Clients/Domains/TLDsApiInfoTest.php
+++ b/tests/Clients/Domains/TLDsApiInfoTest.php
@@ -33,6 +33,22 @@ class TLDsApiInfoTest extends TestCase
         Assert::assertSame(113, $languageCodes->count());
     }
 
+    public function test_info_com_nullables(): void
+    {
+        $json = file_get_contents(__DIR__ . '/../../Domain/data/tldinfo_com-nullables.json');
+
+        assert(is_string($json));
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            $json,
+            MockedClientFactory::assertRoute('GET', 'v2/tlds/com/info', $this)
+        );
+
+        $response = $sdk->tlds->info('com');
+        $this->assertInstanceOf(TLDInfo::class, $response);
+    }
+
     public function test_info_nl(): void
     {
         $json = file_get_contents(__DIR__ . '/../../Domain/data/tldinfo_nl.json');

--- a/tests/Domain/data/tldinfo_com-nullables.json
+++ b/tests/Domain/data/tldinfo_com-nullables.json
@@ -1,0 +1,89 @@
+{
+    "metadata": {
+        "renewDomainPeriods": [
+            12,
+            24,
+            36,
+            48,
+            60,
+            72,
+            84,
+            96,
+            108,
+            120
+        ],
+        "whoisExposure": "FULL",
+        "gdprCategory": "UNKNOWN",
+        "createDomainPeriods": [
+            12,
+            24,
+            36,
+            48,
+            60,
+            72,
+            84,
+            96,
+            108,
+            120
+        ],
+        "autoRenewDomainPeriods": [
+            12
+        ],
+        "registrant": {
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "adjustableAuthCode": true,
+        "creationRequiresPreValidation": false,
+        "transferFOA": true,
+        "featuresAvailable": [
+            "RESTORE",
+            "CREATE",
+            "PRIVACY_PROTECT",
+            "RENEW",
+            "TRANSFER",
+            "UPDATE"
+        ],
+        "customAuthcodeSupport": true,
+        "adminContacts": {
+            "min": 1,
+            "max": 10,
+            "required": true,
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "billingContacts": {
+            "min": 0,
+            "max": 10,
+            "required": false,
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "techContacts": {
+            "min": 1,
+            "max": 10,
+            "required": true,
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "nameservers": {
+            "min": 0,
+            "max": 10,
+            "required": false
+        },
+        "domainSyntax": {
+            "minLength": 3,
+            "maxLength": 63,
+            "idnType": "UTS46",
+            "idnSupport": true
+        },
+        "transferRequiresAuthcode": true,
+        "transferSupportsAuthcode": true,
+        "registrantChangeApprovalRequired": true
+    },
+    "provider": "Verisign",
+    "applicableFor": [
+        "com",
+        "net"
+    ]
+}


### PR DESCRIPTION
This PR fixes #80 which currently breaks the TLD info API implementation because the fields are non nullable but are not (always) returned by the actual API.

A test has been added that confirms the bug and its solution.