### PR TITLE
Expose validation API client and added test coverage

### DIFF
--- a/src/Domain/ValidationCategory.php
+++ b/src/Domain/ValidationCategory.php
@@ -13,7 +13,7 @@ class ValidationCategory implements DomainObjectInterface
 
     public ValidationCategoryTermsCollection $terms;
 
-    private function __construct(string $name, string $description, array $fields, array $terms)
+    private function __construct(string $name, string $description, ?array $fields, array $terms)
     {
         $this->name = $name;
         $this->description = $description;
@@ -33,11 +33,13 @@ class ValidationCategory implements DomainObjectInterface
 
     public function toArray(): array
     {
-        return [
+        return array_filter([
             'name' => $this->name,
             'description' => $this->description,
             'fields' => $this->fields,
-            'terms' => $this->terms,
-        ];
+            'terms' => $this->terms->toArray(),
+        ], function ($x) {
+            return ! is_null($x);
+        });
     }
 }

--- a/src/Domain/ValidationCategoryTerms.php
+++ b/src/Domain/ValidationCategoryTerms.php
@@ -11,13 +11,13 @@ class ValidationCategoryTerms implements DomainObjectInterface
 
     public string $terms;
 
-    public ?DateTimeInterface $validTill;
+    public ?DateTimeInterface $validUntil;
 
-    private function __construct(int $version, string $terms, ?\DateTimeInterface $validTill)
+    private function __construct(int $version, string $terms, ?\DateTimeInterface $validUntil)
     {
         $this->version = $version;
         $this->terms = $terms;
-        $this->validTill = $validTill;
+        $this->validUntil = $validUntil;
     }
 
     /**
@@ -25,19 +25,23 @@ class ValidationCategoryTerms implements DomainObjectInterface
      */
     public static function fromArray(array $json): ValidationCategoryTerms
     {
+        $validUntil = $json['validUntil'] ?? null;
+
         return new ValidationCategoryTerms(
             $json['version'],
             $json['terms'],
-            $json['validTill'] ? new DateTimeImmutable($json['validTill']) : null
+            $validUntil ? new DateTimeImmutable($validUntil) : null
         );
     }
 
     public function toArray(): array
     {
-        return [
-            'version' => $this->version,
+        return array_filter([
             'terms' => $this->terms,
-            'validTill' => $this->validTill,
-        ];
+            'validUntil' => $this->validUntil?->format('Y-m-d\TH:i:s\Z'),
+            'version' => $this->version,
+        ], function ($x) {
+            return ! is_null($x);
+        });
     }
 }

--- a/src/RealtimeRegister.php
+++ b/src/RealtimeRegister.php
@@ -17,6 +17,7 @@ use RealtimeRegister\Api\NotificationsApi;
 use RealtimeRegister\Api\ProcessesApi;
 use RealtimeRegister\Api\ProvidersApi;
 use RealtimeRegister\Api\TLDsApi;
+use RealtimeRegister\Api\ValidationApi;
 use RealtimeRegister\Support\AuthorizedClient;
 
 final class RealtimeRegister
@@ -51,6 +52,8 @@ final class RealtimeRegister
 
     public FinancialApi $financial;
 
+    public ValidationApi $validation;
+
     public function __construct(
         string $apiKey,
         ?string $baseUrl = null,
@@ -76,5 +79,6 @@ final class RealtimeRegister
         $this->dnszones = new DnsZonesApi($client);
         $this->tlds = new TLDsApi($client);
         $this->financial = new FinancialApi($client);
+        $this->validation = new ValidationApi($client);
     }
 }

--- a/tests/Clients/Validation/ValidationApiGetTest.php
+++ b/tests/Clients/Validation/ValidationApiGetTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace RealtimeRegister\Tests\Clients\Validation;
+
+use PHPUnit\Framework\TestCase;
+use RealtimeRegister\Domain\ValidationCategory;
+use RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class ValidationApiGetTest extends TestCase
+{
+    public function test_get(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode(include __DIR__ . '/../../Domain/data/validation/category_valid_with_valid_until.php'),
+            MockedClientFactory::assertRoute('GET', 'v2/validation/categories/IisNu', $this)
+        );
+
+        $response = $sdk->validation->get('IisNu');
+
+        $this->assertInstanceOf(ValidationCategory::class, $response);
+    }
+}

--- a/tests/Clients/Validation/ValidationApiListTest.php
+++ b/tests/Clients/Validation/ValidationApiListTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types = 1);
+
+namespace RealtimeRegister\Tests\Clients\Validation;
+
+use PHPUnit\Framework\TestCase;
+use RealtimeRegister\Domain\ValidationCategoryCollection;
+use RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class ValidationApiListTest extends TestCase
+{
+    public function test_list(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../../Domain/data/validation/category_valid.php',
+                    include __DIR__ . '/../../Domain/data/validation/category_valid.php',
+                    include __DIR__ . '/../../Domain/data/validation/category_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 10,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/validation/categories', $this)
+        );
+
+        $response = $sdk->validation->list();
+
+        $this->assertInstanceOf(ValidationCategoryCollection::class, $response);
+    }
+
+    public function test_list_with_queries(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../../Domain/data/validation/category_valid.php',
+                    include __DIR__ . '/../../Domain/data/validation/category_valid.php',
+                    include __DIR__ . '/../../Domain/data/validation/category_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 3,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/validation/categories', $this)
+        );
+
+        $response = $sdk->validation->list(3, 0, 'category');
+
+        $this->assertInstanceOf(ValidationCategoryCollection::class, $response);
+    }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $parameters = [
+            'name:like' => 'General',
+        ];
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../../Domain/data/validation/category_valid.php',
+                    include __DIR__ . '/../../Domain/data/validation/category_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 2,
+                    'offset' => 0,
+                    'limit'  => 2,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/validation/categories', $this, [
+                'name:like' => 'General',
+                'limit' => '2',
+                'offset' => '0',
+                'q' => 'category',
+            ])
+        );
+
+        $response = $sdk->validation->list(2, 0, 'category', $parameters);
+
+        $this->assertInstanceOf(ValidationCategoryCollection::class, $response);
+    }
+}

--- a/tests/Domain/DomainCollectionTest.php
+++ b/tests/Domain/DomainCollectionTest.php
@@ -23,6 +23,8 @@ use RealtimeRegister\Domain\PriceCollection;
 use RealtimeRegister\Domain\ProcessCollection;
 use RealtimeRegister\Domain\ProviderCollection;
 use RealtimeRegister\Domain\TemplateCollection;
+use RealtimeRegister\Domain\ValidationCategoryCollection;
+use RealtimeRegister\Domain\ValidationCategoryTermsCollection;
 
 /**
  * This TestCase is used to test all Domain Object Collections.
@@ -50,6 +52,8 @@ class DomainCollectionTest extends TestCase
             'key data collection' => [KeyDataCollection::class, include __DIR__ . '/data/key_data_valid.php'],
             'price collection' => [PriceCollection::class, include __DIR__ . '/data/price_valid.php'],
             'contact property collection' => [ContactPropertyCollection::class, include __DIR__ . '/data/contacts/contact_property_valid.php'],
+            'validation category collection' => [ValidationCategoryCollection::class, include __DIR__ . '/data/validation/category_valid.php'],
+            'validation category terms collection' => [ValidationCategoryTermsCollection::class, include __DIR__ . '/data/validation/category_terms_valid.php'],
             'launch phase collection' => [LaunchPhaseCollection::class, include __DIR__ . '/data/launch_phase.php'],
             'log collection' => [LogCollection::class, include __DIR__ . '/data/log.php'],
             'notification collection' => [NotificationCollection::class, include __DIR__ . '/data/notifications/notification_valid.php'],

--- a/tests/Domain/DomainObjectTest.php
+++ b/tests/Domain/DomainObjectTest.php
@@ -34,6 +34,8 @@ use RealtimeRegister\Domain\Registrant;
 use RealtimeRegister\Domain\Template;
 use RealtimeRegister\Domain\TemplatePreview;
 use RealtimeRegister\Domain\TLDInfo;
+use RealtimeRegister\Domain\ValidationCategory;
+use RealtimeRegister\Domain\ValidationCategoryTerms;
 use RealtimeRegister\Domain\Zone;
 use RealtimeRegister\Exceptions\InvalidArgumentException;
 use TypeError;
@@ -84,6 +86,22 @@ class DomainObjectTest extends TestCase
                 Contact::class,
                 include __DIR__ . '/data/contacts/contact_invalid_name.php',
                 TypeError::class,
+            ],
+            'valid validation category (all fields)' => [
+                ValidationCategory::class,
+                include __DIR__ . '/data/validation/category_valid.php',
+            ],
+            'valid validation category (only required)' => [
+                ValidationCategory::class,
+                include __DIR__ . '/data/validation/category_valid_only_required.php',
+            ],
+            'valid validation category (valid until)' => [
+                ValidationCategory::class,
+                include __DIR__ . '/data/validation/category_valid_with_valid_until.php',
+            ],
+            'valid validation category terms' => [
+                ValidationCategoryTerms::class,
+                include __DIR__ . '/data/validation/category_terms_valid.php',
             ],
             'valid country (all fields)' => [
                 Country::class,

--- a/tests/Domain/data/validation/category_terms_valid.php
+++ b/tests/Domain/data/validation/category_terms_valid.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+return [
+    'terms' => 'https://example.com/iisnu-terms-v4.pdf',
+    'validUntil' => '2026-01-15T00:00:00Z',
+    'version' => 4,
+];

--- a/tests/Domain/data/validation/category_valid.php
+++ b/tests/Domain/data/validation/category_valid.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+return [
+    'name' => 'General',
+    'description' => 'General',
+    'fields' => [
+        'organization',
+        'name',
+        'email',
+    ],
+    'terms' => [
+        [
+            'terms' => 'https://example.com/terms-and-conditions',
+            'version' => 1,
+        ],
+    ],
+];

--- a/tests/Domain/data/validation/category_valid_only_required.php
+++ b/tests/Domain/data/validation/category_valid_only_required.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+return [
+    'name' => 'CIRA',
+    'description' => 'CIRA validation category',
+    'terms' => [
+        [
+            'terms' => 'https://example.com/cira-terms.pdf',
+            'version' => 1,
+        ],
+    ],
+];

--- a/tests/Domain/data/validation/category_valid_with_valid_until.php
+++ b/tests/Domain/data/validation/category_valid_with_valid_until.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+return [
+    'name' => 'IisNu',
+    'description' => 'IisNu validation category',
+    'fields' => [
+        'organization',
+        'name',
+    ],
+    'terms' => [
+        [
+            'terms' => 'https://example.com/iisnu-terms-v5.pdf',
+            'version' => 5,
+        ],
+        [
+            'terms' => 'https://example.com/iisnu-terms-v4.pdf',
+            'validUntil' => '2026-01-15T00:00:00Z',
+            'version' => 4,
+        ],
+    ],
+];

--- a/tests/RealtimeRegisterClientTest.php
+++ b/tests/RealtimeRegisterClientTest.php
@@ -9,6 +9,7 @@ use RealtimeRegister\Api\DomainsApi;
 use RealtimeRegister\Api\NotificationsApi;
 use RealtimeRegister\Api\ProcessesApi;
 use RealtimeRegister\Api\ProvidersApi;
+use RealtimeRegister\Api\ValidationApi;
 use RealtimeRegister\RealtimeRegister;
 use RealtimeRegister\Support\AuthorizedClient;
 
@@ -28,5 +29,6 @@ class RealtimeRegisterClientTest extends TestCase
         $this->assertInstanceOf(NotificationsApi::class, $client->notifications, 'The notifications could not be instantiated.');
         $this->assertInstanceOf(ProvidersApi::class, $client->providers, 'The providers could not be instantiated.');
         $this->assertInstanceOf(ProcessesApi::class, $client->processes, 'The processes could not be instantiated.');
+        $this->assertInstanceOf(ValidationApi::class, $client->validation, 'The validation could not be instantiated.');
     }
 }


### PR DESCRIPTION
ValidationApi already exists but was not exposed on the main SDK client. This change wires it into `RealtimeRegister` 

Changes:
- Exposes ValidationApi through $client->validation.
- Adds validation category list/get client tests.
- Adds validation category domain fixtures and shared parser/collection coverage.
- Allows validation categories without optional fields.
- Aligns validation category term parsing with the API’s validUntil field.